### PR TITLE
Querydsl 구성, 배달 지역 추가, 사용자 배달 가능 식당 검색 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,25 @@ dependencies {
 	implementation 'mysql:mysql-connector-java:8.0.32'
 
 	runtimeOnly 'com.h2database:h2'
+
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+}
+
+def querydslDir = "$buildDir/generated/querydsl"
+
+sourceSets {
+	main.java.srcDirs += [ querydslDir ]
+}
+
+tasks.withType(JavaCompile) {
+	options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
+}
+
+clean.doLast {
+	file(querydslDir).deleteDir()
 }
 
 tasks.named('test') {

--- a/src/main/java/jw/project/baemin/common/config/QuerydslConfig.java
+++ b/src/main/java/jw/project/baemin/common/config/QuerydslConfig.java
@@ -1,0 +1,18 @@
+package jw.project.baemin.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/jw/project/baemin/customer/application/CustomerAddressService.java
+++ b/src/main/java/jw/project/baemin/customer/application/CustomerAddressService.java
@@ -47,6 +47,11 @@ public class CustomerAddressService {
             .collect(Collectors.toList());
     }
 
+    public CustomerAddressResponse findCustomerAddressByIsMain(Long customerId) {
+        return CustomerAddressResponse.from(
+            customerAddressRepository.findByCustomerIdAndIsMainIsTrue(customerId));
+    }
+
     public CustomerAddressResponse updateCustomerAddress(Long id,
         UpdateCustomerAddressRequest request) {
         CustomerAddress customerAddress = validateFindByAddressId(id);

--- a/src/main/java/jw/project/baemin/customer/infrastructure/CustomerAddressRepository.java
+++ b/src/main/java/jw/project/baemin/customer/infrastructure/CustomerAddressRepository.java
@@ -1,11 +1,12 @@
 package jw.project.baemin.customer.infrastructure;
 
 import java.util.List;
-import java.util.Optional;
 import jw.project.baemin.customer.domain.CustomerAddress;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CustomerAddressRepository extends JpaRepository<CustomerAddress, Long> {
 
     List<CustomerAddress> findByCustomerId(Long customerId);
+
+    CustomerAddress findByCustomerIdAndIsMainIsTrue(Long customerId);
 }

--- a/src/main/java/jw/project/baemin/region/application/RegionService.java
+++ b/src/main/java/jw/project/baemin/region/application/RegionService.java
@@ -30,6 +30,9 @@ public class RegionService {
             .orElseThrow(RuntimeException::new);
     }
 
+    public RegionCode findRegionById(Long regionId) {
+        return regionRepository.findById(regionId).orElseThrow(RuntimeException::new);
+    }
 
     private List<RegionCode> parseRegions() {
         String regionFileName = "RegionFile.txt";

--- a/src/main/java/jw/project/baemin/restaurant/delivery/domain/DeliveryRegion.java
+++ b/src/main/java/jw/project/baemin/restaurant/delivery/domain/DeliveryRegion.java
@@ -1,0 +1,55 @@
+package jw.project.baemin.restaurant.delivery.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jw.project.baemin.region.domain.RegionCode;
+import jw.project.baemin.restaurant.restaurant.domain.Restaurant;
+import lombok.Builder;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class DeliveryRegion {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "region_code_id", nullable = false)
+    private RegionCode regionCode;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "restaurant_id", nullable = false)
+    private Restaurant restaurant;
+
+    private Integer deliveryFee;
+
+    public static DeliveryRegion create(RegionCode regionCode, Restaurant restaurant,
+        Integer deliveryFee) {
+        return new DeliveryRegion(regionCode, restaurant, deliveryFee);
+    }
+
+    public DeliveryRegion() {
+    }
+
+    private DeliveryRegion(RegionCode regionCode, Restaurant restaurant, Integer deliveryFee) {
+        this.regionCode = regionCode;
+        this.restaurant = restaurant;
+        this.deliveryFee = deliveryFee;
+    }
+
+    @Builder
+    public DeliveryRegion(Long id, RegionCode regionCode, Restaurant restaurant,
+        Integer deliveryFee) {
+        this.id = id;
+        this.regionCode = regionCode;
+        this.restaurant = restaurant;
+        this.deliveryFee = deliveryFee;
+    }
+}

--- a/src/main/java/jw/project/baemin/restaurant/delivery/infrastructure/DeliveryRegionRepository.java
+++ b/src/main/java/jw/project/baemin/restaurant/delivery/infrastructure/DeliveryRegionRepository.java
@@ -1,0 +1,10 @@
+package jw.project.baemin.restaurant.delivery.infrastructure;
+
+import java.util.List;
+import jw.project.baemin.restaurant.delivery.domain.DeliveryRegion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DeliveryRegionRepository extends JpaRepository<DeliveryRegion, Long> {
+
+    List<DeliveryRegion> findByRegionCodeId(Long regionCodeId);
+}

--- a/src/main/java/jw/project/baemin/restaurant/restaurant/domain/Restaurant.java
+++ b/src/main/java/jw/project/baemin/restaurant/restaurant/domain/Restaurant.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
+import jw.project.baemin.restaurant.delivery.domain.DeliveryRegion;
 import jw.project.baemin.restaurant.restaurant.domain.eums.OrderType;
 import jw.project.baemin.restaurant.restaurant.domain.eums.ShopStatus;
 import jw.project.baemin.restaurant.restaurant.domain.eums.SupportPayment;
@@ -69,6 +70,10 @@ public class Restaurant {
     @Builder.Default
     List<RestaurantCategory> categories = new ArrayList<>();
 
+    @OneToMany(mappedBy = "restaurant", orphanRemoval = true, cascade = CascadeType.ALL)
+    List<DeliveryRegion> deliveryRegions;
+
+
     @CreationTimestamp
     private LocalDateTime createdAt;
 
@@ -85,6 +90,13 @@ public class Restaurant {
 
     public void addCategory(RestaurantCategory category) {
         categories.add(category);
+    }
+
+    public void addDeliveryRegion(DeliveryRegion region) {
+        if (deliveryRegions == null) {
+            deliveryRegions = new ArrayList<>();
+        }
+        deliveryRegions.add(region);
     }
 
     public void changeStatus() {

--- a/src/main/java/jw/project/baemin/restaurant/restaurant/infrastructure/JpaRestaurantRepository.java
+++ b/src/main/java/jw/project/baemin/restaurant/restaurant/infrastructure/JpaRestaurantRepository.java
@@ -1,0 +1,14 @@
+package jw.project.baemin.restaurant.restaurant.infrastructure;
+
+import java.util.List;
+import java.util.Optional;
+import jw.project.baemin.restaurant.restaurant.domain.Restaurant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaRestaurantRepository extends JpaRepository<Restaurant, Long> {
+    List<Restaurant> findByOwnerId(Long ownerId);
+
+    Optional<Restaurant> findByOwnerIdAndId(Long ownerId, Long restaurantId);
+
+    List<Restaurant> findByDeliveryRegionsRegionCode(String regionCodeId);
+}

--- a/src/main/java/jw/project/baemin/restaurant/restaurant/infrastructure/RestaurantRepository.java
+++ b/src/main/java/jw/project/baemin/restaurant/restaurant/infrastructure/RestaurantRepository.java
@@ -1,13 +1,27 @@
 package jw.project.baemin.restaurant.restaurant.infrastructure;
 
+import com.querydsl.core.QueryResults;
 import java.util.List;
 import java.util.Optional;
+import jw.project.baemin.region.domain.RegionCode;
+import jw.project.baemin.restaurant.delivery.domain.DeliveryRegion;
 import jw.project.baemin.restaurant.restaurant.domain.Restaurant;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
+public interface RestaurantRepository{
 
     List<Restaurant> findByOwnerId(Long ownerId);
 
     Optional<Restaurant> findByOwnerIdAndId(Long ownerId, Long restaurantId);
+
+    void deleteById(Long restaurantId);
+
+    Restaurant save(Restaurant restaurant);
+
+    Optional<Restaurant> findById(Long restaurantId);
+
+    Page<Restaurant> findByDeliveryRegionsRegionCode(RegionCode regionCode,
+        List<DeliveryRegion> deliveryRegions, PageRequest pageRequest);
 }

--- a/src/main/java/jw/project/baemin/restaurant/restaurant/infrastructure/RestaurantRepositoryAdapter.java
+++ b/src/main/java/jw/project/baemin/restaurant/restaurant/infrastructure/RestaurantRepositoryAdapter.java
@@ -1,0 +1,73 @@
+package jw.project.baemin.restaurant.restaurant.infrastructure;
+
+import static jw.project.baemin.restaurant.restaurant.domain.QRestaurant.*;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.Optional;
+import jw.project.baemin.region.domain.RegionCode;
+import jw.project.baemin.restaurant.delivery.domain.DeliveryRegion;
+import jw.project.baemin.restaurant.restaurant.domain.QRestaurant;
+import jw.project.baemin.restaurant.restaurant.domain.Restaurant;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class RestaurantRepositoryAdapter implements RestaurantRepository {
+
+    private final JpaRestaurantRepository jpaRestaurantRepository;
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public void deleteById(Long restaurantId) {
+        jpaRestaurantRepository.deleteById(restaurantId);
+    }
+
+    @Override
+    public Restaurant save(Restaurant restaurant) {
+        return jpaRestaurantRepository.save(restaurant);
+    }
+
+    @Override
+    public Optional<Restaurant> findById(Long restaurantId) {
+        return jpaRestaurantRepository.findById(restaurantId);
+    }
+
+    @Override
+    public List<Restaurant> findByOwnerId(Long ownerId) {
+        return jpaRestaurantRepository.findByOwnerId(ownerId);
+    }
+
+    @Override
+    public Optional<Restaurant> findByOwnerIdAndId(Long ownerId, Long restaurantId) {
+        return jpaRestaurantRepository.findByOwnerIdAndId(ownerId, restaurantId);
+    }
+
+
+    @Override
+    public Page<Restaurant> findByDeliveryRegionsRegionCode(RegionCode regionCode,
+        List<DeliveryRegion> deliveryRegions, PageRequest pageRequest) {
+        QRestaurant Qrestaurant = restaurant;
+
+        BooleanExpression containsDeliveryRegion =
+            Qrestaurant.deliveryRegions.any().in(deliveryRegions);
+
+        List<Restaurant> restaurants = queryFactory.selectFrom(Qrestaurant)
+            .where(containsDeliveryRegion)
+            .offset(pageRequest.getOffset())
+            .limit(pageRequest.getPageSize())
+            .fetch();
+
+        JPAQuery<Long> count = queryFactory.select(Qrestaurant.count())
+            .from(Qrestaurant)
+            .where(containsDeliveryRegion);
+
+        return PageableExecutionUtils.getPage(restaurants, pageRequest, count::fetchOne);
+    }
+}

--- a/src/main/java/jw/project/baemin/restaurant/restaurant/presentation/RestaurantController.java
+++ b/src/main/java/jw/project/baemin/restaurant/restaurant/presentation/RestaurantController.java
@@ -4,9 +4,11 @@ import jw.project.baemin.common.ApiResponse;
 import jw.project.baemin.restaurant.restaurant.application.RestaurantService;
 import jw.project.baemin.restaurant.restaurant.domain.eums.OrderType;
 import jw.project.baemin.restaurant.restaurant.domain.eums.SupportPayment;
+import jw.project.baemin.restaurant.restaurant.presentation.request.AddDeliveryRegionRequest;
 import jw.project.baemin.restaurant.restaurant.presentation.request.CreateRestaurantRequest;
 import jw.project.baemin.restaurant.restaurant.presentation.request.UpdateRestaurantRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -14,6 +16,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -86,4 +89,19 @@ public class RestaurantController {
         return ApiResponse.success(
             restaurantService.deleteRestaurantCategory(restaurantId, categoryId));
     }
+
+    @PostMapping("/region")
+    public ApiResponse<?> addDeliveryRegion(@RequestBody AddDeliveryRegionRequest request) {
+        return ApiResponse.success(restaurantService.addDeliveryRegion(request));
+    }
+
+    @GetMapping("/near")
+    public ApiResponse<?> findRestaurantsByRegionCodeId(@RequestParam Long regionCodeId,
+        @RequestParam int page, @RequestParam int size) {
+        PageRequest pageRequest = PageRequest.of(page, size);
+
+        return ApiResponse.success(
+            restaurantService.findRestaurantByRegionCode(regionCodeId, pageRequest));
+    }
+
 }

--- a/src/main/java/jw/project/baemin/restaurant/restaurant/presentation/request/AddDeliveryRegionRequest.java
+++ b/src/main/java/jw/project/baemin/restaurant/restaurant/presentation/request/AddDeliveryRegionRequest.java
@@ -1,0 +1,5 @@
+package jw.project.baemin.restaurant.restaurant.presentation.request;
+
+public record AddDeliveryRegionRequest(Long restaurantId, Long regionCodeId, Integer deliveryFee) {
+
+}


### PR DESCRIPTION
## 📌 PR 설명 
- Querydsl 구성, 배달 지역 추가, 사용자 배달 가능 식당 검색 기능 구현
- 
## 👩‍💻 요구 사항과 구현 내용
- 식당은 배달 지역을 추가할 수 있습니다.
- 사용자는 주소 기반으로 배달 가능한 식당을 검색할 수 있습니다.
- [X] Querydsl 구성 및 기능 구현
- [X] RestaurantRepository Interface 구현, Adapter 패턴을 통한 Querydsl, JPA 혼용
- [X] Restaurant 배달 지역 추가 기능 구현 
- [X] 사용자 주문 가능 식당 검색 기능 구현

## ✅ PR 포인트 & 궁금한 점
- 사용자 주문 가능 식당 검색 기능
- 동적인 Query 사용을 위해 QueryDsl을 사용하였습니다.
- Cursor 방식을 이용하여 주문 가능 식당 리스트를 page 단위로 받아오면서 데이터를 빨리 받아 올 수 있도록 하였습니다.