### PR TITLE
장바구니 아이템 일괄 저장 성능 개선 - JDBC BatchUpdate

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,10 @@ dependencies {
 	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+	implementation 'org.springframework.boot:spring-boot-starter-jdbc:3.1.2'
+	implementation 'com.github.javafaker:javafaker:1.0.2'
+
 }
 
 def querydslDir = "$buildDir/generated/querydsl"

--- a/src/main/java/jw/project/baemin/cart/application/CartService.java
+++ b/src/main/java/jw/project/baemin/cart/application/CartService.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import jw.project.baemin.cart.domain.Cart;
 import jw.project.baemin.cart.domain.CartItem;
-import jw.project.baemin.cart.infrastructure.CartItemRepository;
+import jw.project.baemin.cart.domain.CartItemRepository;
 import jw.project.baemin.cart.infrastructure.CartRepository;
 import jw.project.baemin.cart.presentation.request.AddCartItemToCartRequest;
 import jw.project.baemin.cart.presentation.response.CartItemResponse;
@@ -31,13 +31,23 @@ public class CartService {
         return cartRepository.save(cart).getCustomerId();
     }
 
+    public void addMenus(Long customerId,
+        Long restaurantId, List<AddCartItemToCartRequest> request) {
+        getOrCreateCart(customerId, restaurantId);
+
+        List<CartItem> cartItem = request.stream()
+            .map(item -> item.toEntityForJDBC(customerId))
+            .collect(Collectors.toList());
+
+        cartItemRepository.saveAll(customerId, cartItem);
+    }
+
     public void deleteCartItem(Long cartItemId) {
         cartItemRepository.deleteById(cartItemId);
     }
 
     public CartItemResponse findCartItem(Long cartItemId) {
-        CartItem cartItem = cartItemRepository.findById(cartItemId)
-            .orElseThrow(RuntimeException::new);
+        CartItem cartItem = cartItemRepository.findById(cartItemId);
 
         MenuResponse menu = menuService.findMenu(cartItem.getMenu().getId());
 
@@ -60,8 +70,7 @@ public class CartService {
     }
 
     public Long updateCartItem(Long cartItemId, Integer count) {
-        CartItem cartItem = cartItemRepository.findById(cartItemId)
-            .orElseThrow(RuntimeException::new);
+        CartItem cartItem = cartItemRepository.findById(cartItemId);
 
         cartItem.changeCount(count);
         return cartItemRepository.save(cartItem).getId();

--- a/src/main/java/jw/project/baemin/cart/domain/CartItem.java
+++ b/src/main/java/jw/project/baemin/cart/domain/CartItem.java
@@ -8,7 +8,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
-import jw.project.baemin.order.domain.Order;
+import jakarta.persistence.Transient;
 import jw.project.baemin.restaurant.menu.domain.Menu;
 import lombok.Builder;
 import lombok.Getter;
@@ -25,15 +25,16 @@ public class CartItem {
     @JoinColumn(name = "menu_id")
     private Menu menu;
 
+    @Transient
+    private Long menuId;
+    @Transient
+    private Long cartId;
+
     private Integer count;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "cart_id")
     private Cart cart;
-
-    @ManyToOne
-    @JoinColumn(name = "order_id")
-    private Order order;
 
     public void changeCount(Integer updateCount) {
         this.count = updateCount;
@@ -43,9 +44,12 @@ public class CartItem {
     }
 
     @Builder
-    public CartItem(Long id, Menu menu, Integer count) {
+    public CartItem(Long id, Menu menu, Long menuId, Long cartId, Integer count, Cart cart) {
         this.id = id;
         this.menu = menu;
+        this.menuId = menuId;
+        this.cartId = cartId;
         this.count = count;
+        this.cart = cart;
     }
 }

--- a/src/main/java/jw/project/baemin/cart/domain/CartItemRepository.java
+++ b/src/main/java/jw/project/baemin/cart/domain/CartItemRepository.java
@@ -1,0 +1,15 @@
+package jw.project.baemin.cart.domain;
+
+import java.util.List;
+
+public interface CartItemRepository {
+    CartItem findById(Long id);
+
+    List<CartItem> findByCart(Cart cart);
+
+    void deleteById(Long id);
+
+    CartItem save(CartItem cartItem);
+
+    void saveAll(Long cartId, List<CartItem> cartItems);
+}

--- a/src/main/java/jw/project/baemin/cart/infrastructure/CartItemRepository.java
+++ b/src/main/java/jw/project/baemin/cart/infrastructure/CartItemRepository.java
@@ -1,8 +1,0 @@
-package jw.project.baemin.cart.infrastructure;
-
-import jw.project.baemin.cart.domain.CartItem;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface CartItemRepository extends JpaRepository<CartItem, Long> {
-
-}

--- a/src/main/java/jw/project/baemin/cart/infrastructure/CartItemRepositoryAdapter.java
+++ b/src/main/java/jw/project/baemin/cart/infrastructure/CartItemRepositoryAdapter.java
@@ -1,0 +1,42 @@
+package jw.project.baemin.cart.infrastructure;
+
+import java.util.List;
+import jw.project.baemin.cart.domain.Cart;
+import jw.project.baemin.cart.domain.CartItem;
+import jw.project.baemin.cart.domain.CartItemRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CartItemRepositoryAdapter implements CartItemRepository {
+
+    private final JpaCartItemRepository jpaCartItemRepository;
+
+    private final JdbcCartRepository jdbcCartRepository;
+
+    @Override
+    public CartItem findById(Long id) {
+        return jpaCartItemRepository.findById(id).orElseThrow();
+    }
+
+    @Override
+    public List<CartItem> findByCart(Cart cart) {
+        return jpaCartItemRepository.findByCart(cart);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        jpaCartItemRepository.deleteById(id);
+    }
+
+    @Override
+    public CartItem save(CartItem cartItem) {
+        return jpaCartItemRepository.save(cartItem);
+    }
+
+    @Override
+    public void saveAll(Long cartId, List<CartItem> cartItems) {
+        jdbcCartRepository.saveAll(cartId, cartItems);
+    }
+}

--- a/src/main/java/jw/project/baemin/cart/infrastructure/JdbcCartRepository.java
+++ b/src/main/java/jw/project/baemin/cart/infrastructure/JdbcCartRepository.java
@@ -1,0 +1,43 @@
+package jw.project.baemin.cart.infrastructure;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+import jw.project.baemin.cart.domain.CartItem;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class JdbcCartRepository {
+
+    private final static String TABLE = "Cart_Item";
+    private final JdbcTemplate jdbcTemplate;
+
+    public void saveAll(Long cartId, List<CartItem> cartItems) {
+        String sql = String.format(
+            "INSERT INTO `%s` (count, cart_id, menu_id) VALUES (?, ?, ?)",
+            TABLE);
+
+        jdbcTemplate.batchUpdate(sql, BatchCartItemSetter(cartId, cartItems));
+    }
+
+    private BatchPreparedStatementSetter BatchCartItemSetter(Long cartId, List<CartItem> cartList) {
+        return new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                CartItem cartItem = cartList.get(i);
+                ps.setInt(1, cartItem.getCount());
+                ps.setLong(2, cartId);
+                ps.setLong(3, cartItem.getMenuId());
+            }
+
+            @Override
+            public int getBatchSize() {
+                return cartList.size();
+            }
+        };
+    }
+}

--- a/src/main/java/jw/project/baemin/cart/infrastructure/JpaCartItemRepository.java
+++ b/src/main/java/jw/project/baemin/cart/infrastructure/JpaCartItemRepository.java
@@ -1,0 +1,10 @@
+package jw.project.baemin.cart.infrastructure;
+
+import java.util.List;
+import jw.project.baemin.cart.domain.Cart;
+import jw.project.baemin.cart.domain.CartItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaCartItemRepository extends JpaRepository<CartItem, Long> {
+     List<CartItem> findByCart(Cart cart);
+}

--- a/src/main/java/jw/project/baemin/cart/presentation/CartController.java
+++ b/src/main/java/jw/project/baemin/cart/presentation/CartController.java
@@ -1,11 +1,11 @@
 package jw.project.baemin.cart.presentation;
 
+import java.util.List;
 import jw.project.baemin.cart.application.CartService;
 import jw.project.baemin.cart.presentation.request.AddCartItemToCartRequest;
 import jw.project.baemin.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,10 +25,11 @@ public class CartController {
         return ApiResponse.success(
             cartService.addDeliveryMenuToCart(customerId, restaurantId, request));
     }
-
-    @GetMapping("/{customerId}")
-    public ApiResponse<?> findAllCartItems(@PathVariable Long customerId) {
-        return ApiResponse.success(cartService.findAllCartItems(customerId));
+    @PostMapping("/{customerId}/restaurant/{restaurantId}/all")
+    public ApiResponse<?> addMenus(@PathVariable Long customerId,
+        @PathVariable Long restaurantId, @RequestBody List<AddCartItemToCartRequest> request) {
+        cartService.addMenus(customerId, restaurantId, request);
+        return ApiResponse.success(null);
     }
 
     @DeleteMapping("/{cartItemId}")

--- a/src/main/java/jw/project/baemin/cart/presentation/request/AddCartItemToCartRequest.java
+++ b/src/main/java/jw/project/baemin/cart/presentation/request/AddCartItemToCartRequest.java
@@ -9,4 +9,12 @@ public record AddCartItemToCartRequest(Long menuId, Integer count, BigDecimal pr
             .count(count)
             .build();
     }
+
+    public CartItem toEntityForJDBC(Long cartId) {
+        return CartItem.builder()
+            .menuId(menuId)
+            .cartId(cartId)
+            .count(count)
+            .build();
+    }
 }

--- a/src/test/java/jw/project/baemin/cart/application/CartServiceTest.java
+++ b/src/test/java/jw/project/baemin/cart/application/CartServiceTest.java
@@ -9,7 +9,7 @@ import java.math.BigDecimal;
 import java.util.Optional;
 import jw.project.baemin.cart.domain.Cart;
 import jw.project.baemin.cart.domain.CartItem;
-import jw.project.baemin.cart.infrastructure.CartItemRepository;
+import jw.project.baemin.cart.infrastructure.JpaCartItemRepository;
 import jw.project.baemin.cart.infrastructure.CartRepository;
 import jw.project.baemin.cart.presentation.request.AddCartItemToCartRequest;
 import jw.project.baemin.support.IntegrationTestSupport;
@@ -21,7 +21,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 public class CartServiceTest extends IntegrationTestSupport {
 
     @MockBean
-    CartItemRepository cartItemRepository;
+    JpaCartItemRepository jpaCartItemRepository;
 
     @MockBean
     CartRepository cartRepository;

--- a/src/test/java/jw/project/baemin/cart/application/PerformanceTest.java
+++ b/src/test/java/jw/project/baemin/cart/application/PerformanceTest.java
@@ -1,0 +1,78 @@
+package jw.project.baemin.cart.application;
+
+import com.github.javafaker.Faker;
+import java.util.ArrayList;
+import java.util.List;
+import jw.project.baemin.cart.domain.Cart;
+import jw.project.baemin.cart.domain.CartItem;
+import jw.project.baemin.cart.domain.CartItemRepository;
+import jw.project.baemin.cart.infrastructure.CartRepository;
+import jw.project.baemin.cart.infrastructure.JpaCartItemRepository;
+import jw.project.baemin.restaurant.menu.domain.Menu;
+import jw.project.baemin.restaurant.menu.infrastructure.MenuRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.util.StopWatch;
+
+@SpringBootTest
+public class PerformanceTest {
+
+    @Autowired
+    CartRepository cartRepository;
+    @Autowired
+    MenuRepository menuRepository;
+    @Autowired
+    CartItemRepository cartItemRepository;
+
+    @Autowired
+    JpaCartItemRepository jpaCartItemRepository;
+
+    List<CartItem> cartItems;
+
+    @BeforeEach
+    void init() {
+        Faker faker = new Faker();
+        cartItems = new ArrayList<>();
+        Cart cart = cartRepository.findById(1L).orElseThrow(RuntimeException::new);
+
+        for (int i = 1; i < 100000; i++) {
+            Menu menu = menuRepository.findById((long) (i)).orElseThrow();
+            CartItem cartItem = CartItem.builder()
+                .cart(cart)
+                .menu(menu)
+                .count(faker.number().numberBetween(1, 10))
+                .build();
+
+            cartItems.add(cartItem);
+        }
+    }
+
+    @Test
+    void Generate_CartItem_By_JDBC() {
+        Long cartId = 1L;
+        StopWatch stopWatch = new StopWatch();
+
+        stopWatch.start();
+        cartItemRepository.saveAll(cartId, cartItems);
+        stopWatch.stop();
+
+        System.out.println("------------Test result------------");
+        System.out.println(stopWatch.getTotalTimeSeconds());
+        System.out.println("-----------------------------------");
+    }
+
+    @Test
+    void Generate_CartItem_By_JPA() {
+        StopWatch stopWatch = new StopWatch();
+
+        stopWatch.start();
+        jpaCartItemRepository.saveAll(cartItems);
+        stopWatch.stop();
+
+        System.out.println("------------Test result------------");
+        System.out.println(stopWatch.getTotalTimeSeconds());
+        System.out.println("-----------------------------------");
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,6 +1,24 @@
 spring:
   datasource:
-    driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:testdb;MODE=MySQL
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/test?rewriteBatchedStatements=true
+    username: root
+    password: 1234
+  jpa:
+    hibernate:
+      ddl-auto: none
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: true
+    database: mysql
+  h2:
+    console: true
+    path: /h2-console
+
+test:
+  datasource:
+    url: jdbc:h2:mem:testdb
     username: sa
     password:
+    driver-class-name: org.h2.Driver


### PR DESCRIPTION
## 📌 PR 설명 
- JDBC BatchUpdate를 이용하여 장바구니에 아이템을 일괄 저장하는 기능 구현

## 👩‍💻 요구 사항과 구현 내용
- 고객은 장바구니에 물건을 여러 개 담을 수 있다.

- [X] JDBC Dependency 등록 및 Bulk Insert를 위한 rewriteBatchedStatements 설정 변경
- [X] JdbcRepository SaveAll(일괄 저장) 기능 구현
- [X] JPA, JdbcRepository SaveAll 성능 비교 Test
- [X] JDBC, JPA 혼용 사용을 위한 CartItemRepositoryAdapter 구현
- [X] 일괄 저장 기능 [Controller, Service] 구현

## ✅ PR 포인트 & 궁금한 점
- 기존 JPA의 saveAll() 메소드는 Item List들의 item 마다 DB에 저장 요청을 보내는 형식으로 비효율적인 방식이었습니다.
- JPA의 Identity 키 생성 방식은 Entity를 영속성 컨텍스트에 등록하기 위해서는 먼저 DB에 insert 요청을 보내고 id를 얻어오는 방식입니다.
- 영속성 컨텍스트를 이용하지 않고 DB에 ID 생성을 맡기는 JDBC를 이용하여 일괄 저장을 하여 성능을 개선하였습니다.
- Adapter 패턴을 이용하여 장바구니 관련 기능을 JPA와 JDBC를 혼용하여 구현하였습니다.
